### PR TITLE
Extend Base's svdvals!. This allows e.g. cond and norm for BigFloat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ os:
   - osx
 
 julia:
-  - 0.4
+  - 0.5
   - nightly
 
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd())'
-  - julia --check-bounds=yes -e 'Pkg.test("LinearAlgebra")'
+# script:
+#   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#   - julia --check-bounds=yes -e 'Pkg.clone(pwd())'
+#   - julia --check-bounds=yes -e 'Pkg.test("LinearAlgebra")'
 
 after_success:
   - julia -e 'cd(Pkg.dir("LinearAlgebra")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,9 @@ os:
   - osx
 
 julia:
+  - 0.4
   - 0.5
   - nightly
-
-# script:
-#   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#   - julia --check-bounds=yes -e 'Pkg.clone(pwd())'
-#   - julia --check-bounds=yes -e 'Pkg.test("LinearAlgebra")'
 
 after_success:
   - julia -e 'cd(Pkg.dir("LinearAlgebra")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,41 @@
-LinearAlgebra.jl
+# LinearAlgebra.jl
 ========
 
-A fresh approach to numerical linear algebra in Julia
+### A fresh approach to numerical linear algebra in Julia
+
+The purpose of this package is partly to extend linear algebra functionality in base to cover generic element types, e.g. `BigFloat` and `Quaternion`, and partly to be a place to experiment with fast linear algebra routines written in Julia (except for optimized BLAS). It is my hope that it is possible to have implementations that are generic, fast, and readable.
+
+So far, this has mainly been my playground but you might find some of the functionality here useful. The package has a generic implementation of a singular value solver (vectors not handled yet) which will make it possible to compute `norm` and `cond` of matrices of `BigFloat`. The package extends the necessary method (`svdvals!`) in base. Hence
+
+```jl
+julia> using LinearAlgebra
+
+julia> A = big(randn(10,10));
+
+julia> cond(A)
+1.266829904721752610946505846921202851190952179974780602509001252204638657237828e+03
+
+julia> norm(A)
+6.370285271475041598951769618847832429030388948627697440637424244721679386430589
+```
+
+The package also includes functions for the blocked Cholesky and QR factorization, the self-adjoint (symmetric) and the general eigenvalue problem. None of these functions are exported or extend Base methods, so, for now, the functions must be fully qualified
+
+```jl
+julia> using LinearAlgebra
+A
+julia> A = randn(1000,1000); A = A'A;
+
+julia> @time cholfact(A)
+
+julia> @time cholfact(A);
+  0.013036 seconds (16 allocations: 7.630 MB)
+
+julia> LinearAlgebra.CholeskyModule.cholRec!(copy(A), Val{:L});
+
+julia> @time LinearAlgebra.CholeskyModule.cholRec!(copy(A), Val{:L});
+  0.012098 seconds (7.00 k allocations: 7.934 MB)
+```
 
 <!-- [![StatsBase](http://pkg.julialang.org/badges/StatsBase_0.4.svg)](http://pkg.julialang.org/?pkg=StatsBase&ver=0.4) -->
 [![Build Status](https://travis-ci.org/andreasnoack/LinearAlgebra.jl.svg?branch=master)](https://travis-ci.org/andreasnoack/LinearAlgebra.jl)

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
-julia 0.5
+julia 0.4
+Compat 0.8.6

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.4
-Compat
+julia 0.5

--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -3,6 +3,9 @@ module CholeskyModule
     using ..JuliaBLAS
     using Base.LinAlg: A_rdiv_Bc!
 
+    using Compat
+    import Compat.view
+
     function cholUnblocked!{T<:Number}(A::AbstractMatrix{T}, ::Type{Val{:L}})
         n = Compat.LinAlg.checksquare(A)
         A[1,1] = sqrt(A[1,1])

--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -7,10 +7,10 @@ module CholeskyModule
         n = Compat.LinAlg.checksquare(A)
         A[1,1] = sqrt(A[1,1])
         if n > 1
-            a21 = sub(A, 2:n, 1)
+            a21 = view(A, 2:n, 1)
             scale!(a21, inv(real(A[1,1])))
 
-            A22 = sub(A, 2:n, 2:n)
+            A22 = view(A, 2:n, 2:n)
             rankUpdate!(-one(T), a21, Hermitian(A22, :L))
             cholUnblocked!(A22, Val{:L})
         end
@@ -20,13 +20,13 @@ module CholeskyModule
     function cholBlocked!{T<:Number}(A::AbstractMatrix{T}, ::Type{Val{:L}}, blocksize::Integer)
         n = Compat.LinAlg.checksquare(A)
         mnb = min(n, blocksize)
-        A11 = sub(A, 1:mnb, 1:mnb)
+        A11 = view(A, 1:mnb, 1:mnb)
         cholUnblocked!(A11, Val{:L})
         if n > blocksize
-            A21 = sub(A, blocksize+1:n, 1:blocksize)
+            A21 = view(A, blocksize+1:n, 1:blocksize)
             A_rdiv_Bc!(A21, LowerTriangular(A11))
 
-            A22 = sub(A, blocksize+1:n, blocksize+1:n)
+            A22 = view(A, blocksize+1:n, blocksize+1:n)
             rankUpdate!(-real(one(T)), A21, Hermitian(A22, :L))
             cholBlocked!(A22, Val{:L}, blocksize)
         end
@@ -41,12 +41,12 @@ module CholeskyModule
             cholUnblocked!(A, Val{:L})
         else
             n2 = div(n, 2)
-            A11 = sub(A, 1:n2, 1:n2)
+            A11 = view(A, 1:n2, 1:n2)
             cholRec!(A11, Val{:L})
-            A21 = sub(A, n2 + 1:n, 1:n2)
+            A21 = view(A, n2 + 1:n, 1:n2)
             A_rdiv_Bc!(A21, LowerTriangular(A11))
 
-            A22 = sub(A, n2 + 1:n, n2 + 1:n)
+            A22 = view(A, n2 + 1:n, n2 + 1:n)
             rankUpdate!(-real(one(T)), A21, Hermitian(A22, :L))
             cholRec!(A22, Val{:L}, cutoff)
         end

--- a/src/eigenGeneral.jl
+++ b/src/eigenGeneral.jl
@@ -4,10 +4,12 @@ module EigenGeneral
 
     using ..HouseholderModule: Householder
     using Base.LinAlg: Givens, Rotation
-    using Compat
 
     import Base: A_mul_B!, A_mul_Bc!, Ac_mul_B, A_mul_Bc, A_ldiv_B!, ctranspose, full, getindex, size
     import Base.LinAlg: QRPackedQ
+
+    using Compat
+    import Compat.view
 
     # Auxiliary
     function adiagmax(A::StridedMatrix)

--- a/src/eigenGeneral.jl
+++ b/src/eigenGeneral.jl
@@ -37,7 +37,7 @@ module EigenGeneral
         Hd = H.data
         for i = 1:n-1
             G, _ = givens!(Hd, i, i+1, i)
-            A_mul_B!(G, sub(Hd, 1:n, i+1:n))
+            A_mul_B!(G, view(Hd, 1:n, i+1:n))
             A_mul_B!(G, B)
         end
         A_ldiv_B!(Triangular(Hd, :U), B)
@@ -53,12 +53,12 @@ module EigenGeneral
         n = Compat.LinAlg.checksquare(A)
         τ = Array(Householder{T}, n - 1)
         for i = 1:n - 1
-            xi = sub(A, i + 1:n, i)
+            xi = view(A, i + 1:n, i)
             t  = LinAlg.reflector!(xi)
-            H  = Householder{T,typeof(xi)}(sub(xi, 2:n - i), t)
+            H  = Householder{T,typeof(xi)}(view(xi, 2:n - i), t)
             τ[i] = H
-            Ac_mul_B!(H, sub(A, i + 1:n, i + 1:n))
-            A_mul_B!(sub(A, :, i + 1:n), H)
+            Ac_mul_B!(H, view(A, i + 1:n, i + 1:n))
+            A_mul_B!(view(A, :, i + 1:n), H)
         end
         return HessenbergFactorization{T, typeof(A), eltype(τ)}(A, τ)
     end
@@ -150,18 +150,18 @@ module EigenGeneral
             HH[istart + 2, istart] = 0
         end
         G, _ = givens(H11 - shift, H21, istart, istart + 1)
-        A_mul_B!(G, sub(HH, :, istart:m))
-        A_mul_Bc!(sub(HH, 1:min(istart + 2, iend), :), G)
+        A_mul_B!(G, view(HH, :, istart:m))
+        A_mul_Bc!(view(HH, 1:min(istart + 2, iend), :), G)
         A_mul_B!(G, τ)
         for i = istart:iend - 2
             G, _ = givens(HH[i + 1, i], HH[i + 2, i], i + 1, i + 2)
-            A_mul_B!(G, sub(HH, :, i:m))
+            A_mul_B!(G, view(HH, :, i:m))
             HH[i + 2, i] = Htmp
             if i < iend - 2
                 Htmp = HH[i + 3, i + 1]
                 HH[i + 3, i + 1] = 0
             end
-            A_mul_Bc!(sub(HH, 1:min(i + 3, iend), :), G)
+            A_mul_Bc!(view(HH, 1:min(i + 3, iend), :), G)
             # A_mul_B!(G, τ)
         end
         return HH
@@ -179,10 +179,10 @@ module EigenGeneral
         HH[istart + 3, istart + 1] = 0
         G1, r = givens(H11*H11 + HH[istart, istart + 1]*H21 - shiftTrace*H11 + shiftDeterminant, H21*(H11 + HH[istart + 1, istart + 1] - shiftTrace), istart, istart + 1)
         G2, _ = givens(r, H21*HH[istart + 2, istart + 1], istart, istart + 2)
-        vHH = sub(HH, :, istart:m)
+        vHH = view(HH, :, istart:m)
         A_mul_B!(G1, vHH)
         A_mul_B!(G2, vHH)
-        vHH = sub(HH, 1:istart + 3, :)
+        vHH = view(HH, 1:istart + 3, :)
         A_mul_Bc!(vHH, G1)
         A_mul_Bc!(vHH, G2)
         A_mul_B!(G1, τ)
@@ -192,7 +192,7 @@ module EigenGeneral
                 if i + j + 1 > iend break end
                 # G, _ = givens(H.H,i+1,i+j+1,i)
                 G, _ = givens(HH[i + 1, i], HH[i + j + 1, i], i + 1, i + j + 1)
-                A_mul_B!(G, sub(HH, :, i:m))
+                A_mul_B!(G, view(HH, :, i:m))
                 HH[i + j + 1, i] = Htmp11
                 Htmp11 = Htmp21
                 # if i + j + 2 <= iend
@@ -203,7 +203,7 @@ module EigenGeneral
                     Htmp22 = HH[i + 4, i + j]
                     HH[i + 4, i + j] = 0
                 end
-                A_mul_Bc!(sub(HH, 1:min(i + j + 2, iend), :), G)
+                A_mul_Bc!(view(HH, 1:min(i + j + 2, iend), :), G)
                 # A_mul_B!(G, τ)
             end
         end

--- a/src/eigenSelfAdjoint.jl
+++ b/src/eigenSelfAdjoint.jl
@@ -322,7 +322,7 @@ module EigenSelfAdjoint
         u = Array(T,n,1)
         @inbounds begin
         for k = 1:n-2+!(T<:Real)
-            τk = LinAlg.reflector!(slice(AS, k + 1:n, k))
+            τk = LinAlg.reflector!(view(AS, k + 1:n, k))
             τ[k] = τk
 
             for i = k+1:n

--- a/src/householder.jl
+++ b/src/householder.jl
@@ -39,11 +39,11 @@ module HouseholderModule
     function A_mul_B!(H::Householder, A::StridedMatrix)
         m, n = size(A)
         length(H.v) == m - 1 || throw(DimensionMismatch(""))
-        v = sub(H.v, 1:m - 1)
+        v = view(H.v, 1:m - 1)
         τ = H.τ
         for j = 1:n
             va = A[1,j]
-            Aj = sub(A, 2:m, j)
+            Aj = view(A, 2:m, j)
             va += dot(v, Aj)
             va = τ*va
             A[1,j] -= va
@@ -55,10 +55,10 @@ module HouseholderModule
     function A_mul_B!(A::StridedMatrix, H::Householder)
         m, n = size(A)
         length(H.v) == n - 1 || throw(DimensionMismatch(""))
-        v = sub(H.v, :)
+        v = view(H.v, :)
         τ = H.τ
-        a1 = sub(A, :, 1)
-        A1 = sub(A, :, 2:n)
+        a1 = view(A, :, 1)
+        A1 = view(A, :, 2:n)
         x = A1*v
         axpy!(one(τ), a1, x)
         axpy!(-τ, x, a1)
@@ -69,11 +69,11 @@ module HouseholderModule
     function Ac_mul_B!(H::Householder, A::StridedMatrix)
         m, n = size(A)
         length(H.v) == m - 1 || throw(DimensionMismatch(""))
-        v = sub(H.v, 1:m - 1)
+        v = view(H.v, 1:m - 1)
         τ = H.τ
         for j = 1:n
             va = A[1,j]
-            Aj = sub(A, 2:m, j)
+            Aj = view(A, 2:m, j)
             va += dot(v, Aj)
             va = τ'va
             A[1,j] -= va
@@ -88,10 +88,10 @@ module HouseholderModule
         nH, blocksize = size(V)
         nH == mA || throw(DimensionMismatch(""))
 
-        V1 = LinAlg.UnitLowerTriangular(sub(V, 1:blocksize, 1:blocksize))
-        V2 = sub(V, blocksize+1:mA, 1:blocksize)
-        A1 = sub(A, 1:blocksize, 1:nA)
-        A2 = sub(A, blocksize+1:mA, 1:nA)
+        V1 = LinAlg.UnitLowerTriangular(view(V, 1:blocksize, 1:blocksize))
+        V2 = view(V, blocksize+1:mA, 1:blocksize)
+        A1 = view(A, 1:blocksize, 1:nA)
+        A2 = view(A, blocksize+1:mA, 1:nA)
         copy!(M, A1)
         Ac_mul_B!(V1, M)
         # M = V1'A1
@@ -110,10 +110,10 @@ module HouseholderModule
         nH, blocksize = size(V)
         nH == mA || throw(DimensionMismatch(""))
 
-        V1 = LinAlg.UnitLowerTriangular(sub(V, 1:blocksize, 1:blocksize))
-        V2 = sub(V, blocksize+1:mA, 1:blocksize)
-        A1 = sub(A, 1:blocksize, 1:nA)
-        A2 = sub(A, blocksize+1:mA, 1:nA)
+        V1 = LinAlg.UnitLowerTriangular(view(V, 1:blocksize, 1:blocksize))
+        V2 = view(V, blocksize+1:mA, 1:blocksize)
+        A1 = view(A, 1:blocksize, 1:nA)
+        A2 = view(A, blocksize+1:mA, 1:nA)
         copy!(M, A1)
         Ac_mul_B!(V1, M)
         # M = V1'A1

--- a/src/lapack.jl
+++ b/src/lapack.jl
@@ -9,7 +9,7 @@ module LAPACK2
             return :( $(Base.blasfunc(x) ))
         end
     else
-        import Base.@blasfunc
+        import Base.BLAS.@blasfunc
     end
 
     ## Standard QR/QL

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -6,6 +6,9 @@ module QRModule
     import Base: getindex, size
     import Base.LinAlg: reflectorApply!
 
+    using Compat
+    import Compat.view
+
     # @inline function reflectorApply!(A::StridedMatrix, x::AbstractVector, τ::Number) # apply reflector from right. It is assumed that the reflector is calculated on the transposed matrix so we apply Q^T, i.e. no conjugation.
     #     m, n = size(A)
     #     if length(x) != n
@@ -55,15 +58,20 @@ module QRModule
     getindex{T,S}(A::QR{T,S}, ::Type{Tuple{:Q}}) = Q{T,typeof(A)}(A)
     function getindex{T,S}(A::QR{T,S}, ::Type{Tuple{:R}})
         m, n = size(A)
-        m >= n ? UpperTriangular(view(A.factors, 1:n, 1:n)) : error("R matrix is trapezoid and cannot be extracted with indexing")
+        if m >= n
+            UpperTriangular(view(A.factors, 1:n, 1:n))
+        else
+            error("R matrix is trapezoid and cannot be extracted with indexing")
+        end
     end
 
     function getindex{T,S}(A::QR{T,S}, ::Type{Tuple{:QBlocked}})
         m, n = size(A)
+        mmn = min(m,n)
         F = A.factors
         τ = A.τ
-        Tmat = zeros(T, n, n)
-        for j = 1:min(m,n)
+        Tmat = zeros(T, mmn, mmn)
+        for j = 1:mmn
             for i = 1:j - 1
                 Tmat[i,j] = τ[i]*(F[j,i] + dot(view(F, j + 1:m, i), view(F, j + 1:m, j)))
             end

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -55,7 +55,7 @@ module QRModule
     getindex{T,S}(A::QR{T,S}, ::Type{Tuple{:Q}}) = Q{T,typeof(A)}(A)
     function getindex{T,S}(A::QR{T,S}, ::Type{Tuple{:R}})
         m, n = size(A)
-        m >= n ? UpperTriangular(sub(A.factors, 1:n, 1:n)) : error("R matrix is trapezoid and cannot be extracted with indexing")
+        m >= n ? UpperTriangular(view(A.factors, 1:n, 1:n)) : error("R matrix is trapezoid and cannot be extracted with indexing")
     end
 
     function getindex{T,S}(A::QR{T,S}, ::Type{Tuple{:QBlocked}})
@@ -65,7 +65,7 @@ module QRModule
         Tmat = zeros(T, n, n)
         for j = 1:min(m,n)
             for i = 1:j - 1
-                Tmat[i,j] = τ[i]*(F[j,i] + dot(sub(F, j + 1:m, i), sub(F, j + 1:m, j)))
+                Tmat[i,j] = τ[i]*(F[j,i] + dot(view(F, j + 1:m, i), view(F, j + 1:m, j)))
             end
         end
         LinAlg.inv!(LinAlg.UnitUpperTriangular(Tmat))
@@ -91,12 +91,12 @@ module QRModule
     end
     function qrBlocked!(A::StridedMatrix, blocksize::Integer, work = Array(eltype(A), blocksize, size(A, 2)))
         m, n = size(A)
-        A1 = sub(A, :, 1:min(n, blocksize))
+        A1 = view(A, :, 1:min(n, blocksize))
         F = qrUnblocked!(A1)
         if n > blocksize
-            A2 = sub(A, :, blocksize + 1:n)
-            Ac_mul_B!(F[Tuple{:QBlocked}], A2, sub(work, 1:blocksize, 1:n - blocksize))
-            qrBlocked!(sub(A, blocksize + 1:m, blocksize + 1:n), blocksize, work)
+            A2 = view(A, :, blocksize + 1:n)
+            Ac_mul_B!(F[Tuple{:QBlocked}], A2, view(work, 1:blocksize, 1:n - blocksize))
+            qrBlocked!(view(A, blocksize + 1:m, blocksize + 1:n), blocksize, work)
         end
         A
     end
@@ -105,7 +105,7 @@ module QRModule
         m, n = size(B)
         Ad = A.data
         for i = 1:m
-            H = householder!(sub(Ad,i,i), sub(B, :, i))
+            H = householder!(view(Ad,i,i), view(B, :, i))
             Ac_mul_B!(H, )
         end
     end

--- a/src/svd.jl
+++ b/src/svd.jl
@@ -102,7 +102,7 @@ function svdDemmelKahan!{T<:Real}(B::Bidiagonal{T}, n1, n2, U = nothing, Vt = no
     return B
 end
 
-function svdvals!{T<:Real}(B::Bidiagonal{T}, tol = eps(T); debug = false, Demmel = false)
+function Base.svdvals!{T<:Real}(B::Bidiagonal{T}, tol = eps(T); debug = false)
 
     n = size(B, 1)
     n1 = 1
@@ -119,9 +119,7 @@ function svdvals!{T<:Real}(B::Bidiagonal{T}, tol = eps(T); debug = false, Demmel
                 if n2i == 1
                     return sort(abs(diag(B)), rev = true) # done
                 else
-                    # FixMe!. Use + until zero shifted algorithm has been implemented. Then
-                    # use * because the precision will be much higher then.
-                    tolcritTop = tol * (abs(d[n2i - 1]) + abs(d[n2i]))
+                    tolcritTop = tol * abs(d[n2i - 1] * d[n2i])
 
                     # debug && println("n2i=", n2i, ", d[n2i-1]=", d[n2i-1], ", d[n2i]=", d[n2i],
                         # ", e[n2i-1]=", e[n2i-1], ", tolcritTop=", tolcritTop)
@@ -139,9 +137,7 @@ function svdvals!{T<:Real}(B::Bidiagonal{T}, tol = eps(T); debug = false, Demmel
                 if n1 == 1
                     break
                 else
-                    # FixMe!. Use + until zero shifted algorithm has been implemented. Then
-                    # use * because the precision will be much higher then.
-                    tolcritBottom = tol * (abs(d[n1 - 1]) + abs(d[n1]))
+                    tolcritBottom = tol * abs(d[n1 - 1] * d[n1])
 
                     # debug && println("n1=", n1, ", d[n1]=", d[n1], ", d[n1-1]=", d[n1-1], ", e[n1-1]", e[n1-1],
                         # ", tolcritBottom=", tolcritBottom)
@@ -174,7 +170,9 @@ function svdvals!{T<:Real}(B::Bidiagonal{T}, tol = eps(T); debug = false, Demmel
             debug && println("count=", count)
         end
     else
-        throw(ArgumentError("lower bidiagonal version not implemented yet"))
+        # Just transpose the matrix. Since we are only interested in the
+        # values here it doesn't matter.
+        return svdvals!(Bidiagonal(d, e, true), tol; debug = debug)
     end
 end
 
@@ -256,38 +254,37 @@ function bidiagonalize!(A::AbstractMatrix)
     if m >= n
         # tall case: lower bidiagonal
         for i = 1:min(m, n)
-            x = slice(A, i:m, i)
+            x = view(A, i:m, i)
             τi = LinAlg.reflector!(x)
             push!(τl, τi)
-            LinAlg.reflectorApply!(x, τi, slice(A, i:m, i + 1:n))
+            LinAlg.reflectorApply!(x, τi, view(A, i:m, i + 1:n))
             if i < n
-                x = slice(A, i, i + 1:n)
+                x = view(A, i, i + 1:n)
                 conj!(x)
                 τi = LinAlg.reflector!(x)
                 push!(τr, τi)
-                LinAlg.reflectorApply!(slice(A, i + 1:m, i + 1:n), x, τi)
+                LinAlg.reflectorApply!(view(A, i + 1:m, i + 1:n), x, τi)
             end
         end
         return Bidiagonal(real(diag(A)), real(diag(A, 1)), true), A, τl, τr
     else
-        # wide vase: upper bidiagonal
+        # wide case: upper bidiagonal
         for i = 1:min(m, n)
-            x = slice(A, i, i:n)
-            conj(x)
+            x = view(A, i, i:n)
             τi = LinAlg.reflector!(x)
             push!(τr, τi)
-            LinAlg.reflectorApply!(x, τi, slice(A, i + 1:m, i:n))
+            LinAlg.reflectorApply!(view(A, i + 1:m, i:n), x, τi)
             if i < m
-                x = slice(A, i + 1:m, i)
+                x = view(A, i + 1:m, i)
                 τi = LinAlg.reflector!(x)
                 push!(τl, τi)
-                LinAlg.reflectorApply!(slice(A, i + 1:m, i + 1:n), x, τi)
+                LinAlg.reflectorApply!(x, τi, view(A, i + 1:m, i + 1:n))
             end
         end
         return Bidiagonal(real(diag(A)), real(diag(A, -1)), false), A, τl, τr
     end
 end
 
-svdvals!(A::StridedMatrix) = svdvals!(bidiagonalize!(A)[1])
+Base.svdvals!(A::StridedMatrix) = svdvals!(bidiagonalize!(A)[1])
 
 end #module

--- a/src/svd.jl
+++ b/src/svd.jl
@@ -1,5 +1,8 @@
 module SVDModule
 
+using Compat
+import Compat.view
+
 import Base: A_mul_B!, A_mul_Bc!
 
 A_mul_B!(G::LinAlg.Givens, ::Void) = nothing

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
+BaseTestNext
 Quaternions

--- a/test/eigengeneral.jl
+++ b/test/eigengeneral.jl
@@ -1,12 +1,20 @@
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
+
 using LinearAlgebra
 
-n = 10
-A = randn(n,n)
-v1 = LinearAlgebra.EigenGeneral.eigvals!(copy(A))
-v2 = eigvals(A)
-vBig = LinearAlgebra.EigenGeneral.eigvals!(big(A))
-@test sort(real(v1)) ≈ sort(real(v2))
-@test sort(imag(v1)) ≈ sort(imag(v2))
-@test sort(real(v1)) ≈ sort(real(map(Complex{Float64}, vBig)))
-@test sort(imag(v1)) ≈ sort(imag(map(Complex{Float64}, vBig)))
+@testset "General eigen problems" begin
+    n = 10
+    A = randn(n,n)
+    v1 = LinearAlgebra.EigenGeneral.eigvals!(copy(A))
+    v2 = eigvals(A)
+    vBig = LinearAlgebra.EigenGeneral.eigvals!(big(A))
+    @test sort(real(v1)) ≈ sort(real(v2))
+    @test sort(imag(v1)) ≈ sort(imag(v2))
+    @test sort(real(v1)) ≈ sort(real(map(Complex{Float64}, vBig)))
+    @test sort(imag(v1)) ≈ sort(imag(map(Complex{Float64}, vBig)))
+end

--- a/test/eigenselfadjoint.jl
+++ b/test/eigenselfadjoint.jl
@@ -1,9 +1,17 @@
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
+
 using LinearAlgebra
 
-n = 10
-T = SymTridiagonal(randn(n), randn(n - 1))
-vals, vecs  = LinearAlgebra.EigenSelfAdjoint.eig(T)
-@test (vecs*Diagonal(vals))*vecs' ≈ full(T)
-vals, vecs2 = LinearAlgebra.EigenSelfAdjoint.eig2(T)
-@test vecs[[1,end],:] == vecs2
+@testset "The selfadjoint eigen problem" begin
+    n = 10
+    T = SymTridiagonal(randn(n), randn(n - 1))
+    vals, vecs  = LinearAlgebra.EigenSelfAdjoint.eig(T)
+    @test (vecs*Diagonal(vals))*vecs' ≈ full(T)
+    vals, vecs2 = LinearAlgebra.EigenSelfAdjoint.eig2(T)
+    @test vecs[[1,end],:] == vecs2
+end

--- a/test/qr.jl
+++ b/test/qr.jl
@@ -1,12 +1,24 @@
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
+
 using Base.LAPACK
 using LinearAlgebra
 using LinearAlgebra.QRModule.qrUnblocked!
 
-m, n = 10, 5
 
-A = randn(m, n)
-Aqr = qrUnblocked!(copy(A))
-AqrQ = Aqr[Tuple{:QBlocked}]
-@test AqrQ'A ≈ [Aqr[Tuple{:R}]; zeros(m - n, n)]
-@test AqrQ'*(AqrQ*A) ≈ A
+@testset "The QR decomposition. Problem dimension ($m,$n)" for (m, n) = ((10, 5), (10, 10), (5, 10))
+
+    A = randn(m, n)
+    Aqr = qrUnblocked!(copy(A))
+    AqrQ = Aqr[Tuple{:QBlocked}]
+    if m >= n
+        @test (AqrQ'A)[1:min(m,n),:] ≈ Aqr[Tuple{:R}]
+    else # For type stbility getindex(,Tuple{:R}) throw when the output is trapezoid
+        @test (AqrQ'A) ≈ triu(Aqr.factors)
+    end
+    @test AqrQ'*(AqrQ*A) ≈ A
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,14 @@
-include("qr.jl")
-include("eigenselfadjoint.jl")
-include("eigengeneral.jl")
-include("tridiag.jl")
-include("svd.jl")
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
+
+@testset "The LinearAlgebra Test Suite" begin
+    include("qr.jl")
+    include("eigenselfadjoint.jl")
+    include("eigengeneral.jl")
+    include("tridiag.jl")
+    include("svd.jl")
+end

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -1,31 +1,39 @@
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
+
 using LinearAlgebra
 using Quaternions
 
-let m = 6, n = 5
+@testset "Singular value decomposition" begin
+    @testset "Problem dimension ($m,$n)" for (m,n) in ((6,5), (6,6), (5,6))
 
-    vals = reverse(collect(1:min(m,n)))
-    U = qr(Quaternion{Float64}[Quaternion(randn(4)...) for i = 1:m, j = 1:n])[1]
-    V = qr(Quaternion{Float64}[Quaternion(randn(4)...) for i = 1:n, j = 1:n])[1]
+        vals = reverse(collect(1:min(m,n)))
+        U = qr(Quaternion{Float64}[Quaternion(randn(4)...) for i = 1:m, j = 1:min(m,n)])[1]
+        V = qr(Quaternion{Float64}[Quaternion(randn(4)...) for i = 1:min(m,n), j = 1:n])[1]
 
-    A = U*Diagonal(vals)*V'
+        A = U*Diagonal(vals)*V'
 
-    @test vals ≈ svdvals(A)
-end
+        @test vals ≈ svdvals(A)
+    end
 
-# This matrix used to hang (for n = 70). Thanks to Ivan Slapnicar for reporting.
-let n = 70
-    J = Bidiagonal(0.5 * ones(n), ones(n-1), true)
-    @test LinearAlgebra.SVDModule.svdvals!(copy(J)) ≈ svdvals(J)
-    @test LinearAlgebra.SVDModule.svdvals!(copy(J))[end] / svdvals(J)[end] - 1 < n*eps()
-end
+    @testset "The Ivan Slapničar Challenge" begin
+        # This matrix used to hang (for n = 70). Thanks to Ivan Slapničar for reporting.
+        n = 70
+        J = Bidiagonal(0.5 * ones(n), ones(n-1), true)
+        @test LinearAlgebra.SVDModule.svdvals!(copy(J)) ≈ svdvals(J)
+        @test LinearAlgebra.SVDModule.svdvals!(copy(J))[end] / svdvals(J)[end] - 1 < n*eps()
+    end
 
-# Test that we extend the base method correctly
-## Tall case
-for (m, n) in ((10,9), # tall
+    @testset "Extending Base methods. Problem dimension" for (m, n) in ((10,9), # tall
                (10,10),# square
                (9,10)) # wide
-    A = randn(m,n)
-    @test svdvals(A) ≈ Vector{Float64}(svdvals(big(A)))
-    @test cond(A) ≈ Float64(cond(big(A)))
+
+        A = randn(m,n)
+        @test svdvals(A) ≈ Vector{Float64}(svdvals(big(A)))
+        @test cond(A) ≈ Float64(cond(big(A)))
+    end
 end

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -2,19 +2,30 @@ using Base.Test
 using LinearAlgebra
 using Quaternions
 
-m = 6
-n = 5
+let m = 6, n = 5
 
-vals = reverse(collect(1:min(m,n)))
-U = qr(Quaternion{Float64}[Quaternion(randn(4)...) for i = 1:m, j = 1:n])[1]
-V = qr(Quaternion{Float64}[Quaternion(randn(4)...) for i = 1:n, j = 1:n])[1]
+    vals = reverse(collect(1:min(m,n)))
+    U = qr(Quaternion{Float64}[Quaternion(randn(4)...) for i = 1:m, j = 1:n])[1]
+    V = qr(Quaternion{Float64}[Quaternion(randn(4)...) for i = 1:n, j = 1:n])[1]
 
-A = U*Diagonal(vals)*V'
+    A = U*Diagonal(vals)*V'
 
-@test vals ≈ LinearAlgebra.SVDModule.svdvals!(A) # right now svdvals! also returns the iteration count. This should probably change
+    @test vals ≈ svdvals(A)
+end
 
 # This matrix used to hang (for n = 70). Thanks to Ivan Slapnicar for reporting.
-n = 70
-J = Bidiagonal(0.5 * ones(n), ones(n-1), true)
-@test LinearAlgebra.SVDModule.svdvals!(copy(J)) ≈ svdvals(J)
-@test LinearAlgebra.SVDModule.svdvals!(copy(J))[end] / svdvals(J)[end] - 1 < n*eps()
+let n = 70
+    J = Bidiagonal(0.5 * ones(n), ones(n-1), true)
+    @test LinearAlgebra.SVDModule.svdvals!(copy(J)) ≈ svdvals(J)
+    @test LinearAlgebra.SVDModule.svdvals!(copy(J))[end] / svdvals(J)[end] - 1 < n*eps()
+end
+
+# Test that we extend the base method correctly
+## Tall case
+for (m, n) in ((10,9), # tall
+               (10,10),# square
+               (9,10)) # wide
+    A = randn(m,n)
+    @test svdvals(A) ≈ Vector{Float64}(svdvals(big(A)))
+    @test cond(A) ≈ Float64(cond(big(A)))
+end

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -1,7 +1,14 @@
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 using LinearAlgebra
 
-n = 20
-T = SymTridiagonal(randn(n), randn(n-1))
-@test numnegevals(T) == count(x->x<0, eigvals(T))
+@testset "Test sign of eigenvalues" begin
+    n = 20
+    T = SymTridiagonal(randn(n), randn(n-1))
+    @test numnegevals(T) == count(x->x<0, eigvals(T))
+end
 


### PR DESCRIPTION
matrices.

Fix bug in bidiagonalization procedure for wide matrices

Suppert svdvals! for wide matrices by commenting out the check (it does
matter if the matrix is upper or lower when we only want the values)

Adjust convergence criterion. We now start with a zero shift so we should
be able to have high relative accuracy.

Remove outdated comments.